### PR TITLE
Fix lambda permssion

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -82,6 +82,16 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Ref FunctionPolicy
+  FunctionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Action: 'ec2:*'
+            Resource: '*'
 Outputs:
   FunctionApi:
     Description: "API Gateway Host URL for Prod stage for mongo check function"


### PR DESCRIPTION
Got this error on deployment of lambda:

The provided execution role does not have permissions to call
CreateNetworkInterface on EC2 (Service: AWSLambdaInternal;
Status Code: 400; Error Code: InvalidParameterValueException;
Request ID: fb77138b-b976-4b90-9668-def03001db05)

This is an attempt to fix the permission.